### PR TITLE
update prior master-dupe pairings

### DIFF
--- a/string_grouper/string_grouper.py
+++ b/string_grouper/string_grouper.py
@@ -192,6 +192,11 @@ class StringGrouper(object):
     def add_match(self, master_side: str, dupe_side: str) -> 'StringGrouper':
         """Adds a match if it wasn't found by the fit function"""
         master_indices, dupe_indices = self._get_indices_of(master_side, dupe_side)
+
+        # add prior matches to new match 
+        dupe_indices = dupe_indices.append( self._matches_list.master_side[self._matches_list.dupe_side.isin(dupe_indices)] )
+        dupe_indices.drop_duplicates(inplace=True)
+
         similarities = [1]
 
         # cross join the indices
@@ -200,7 +205,8 @@ class StringGrouper(object):
         if self._duplicates is None:
             new_matches = StringGrouper._make_symmetric(new_matches)
         # update the matches
-        self._matches_list = pd.concat([self._matches_list, new_matches])
+        self._matches_list = pd.concat([self._matches_list.drop_duplicates(), new_matches], ignore_index=True)
+        
         return self
 
     @validate_is_fit

--- a/string_grouper/test/test_string_grouper.py
+++ b/string_grouper/test/test_string_grouper.py
@@ -282,5 +282,25 @@ class StringGrouperTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             _ = StringGrouper(pd.Series(['foo', np.nan]), pd.Series(['foo', 'j']))
 
+
+    def test_prior_matches_added(self):
+        """When a new match is added, any pre-existing matches should also be updated""""
+        sample = [
+            'microsoftoffice 365 home',
+            'microsoftoffice 365 pers',
+            'microsoft office'
+            ]
+
+        df = pd.DataFrame(sample, columns=['name'])
+
+        sg = StringGrouper(df['name'])
+        sg = sg.fit()
+
+        sg = sg.add_match('microsoft office','microsoftoffice 365 home')
+        sg = sg.add_match('microsoftoffice 365 pers','microsoft office')
+        df['deduped'] = sg.get_groups()
+
+        self.assertEqual(1, len(df.deduped.unique()))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When adding a new match, prior matches made to `master` and `dupe` pairs will also be added to `_matches_list` so that new matches flow through. 

The following toy example demonstrates how the issue:

```
sample = [
    'microsoftoffice 365 home',
    'microsoftoffice 365 pers',
    'microsoft office'
    ]

df = pd.DataFrame(sample, columns=['name'])

sg = StringGrouper(df['name'])
sg = sg.fit()

sg = sg.add_match('microsoft office','microsoftoffice 365 home')
sg = sg.add_match('microsoftoffice 365 pers','microsoft office')
df['deduped'] = sg.get_groups()
```

The existing code will not make add a master-dupe entry for 'microsoftoffice 365 pers' and 'microsoftoffice 365 home' in `_matches_list`, so `microsoftoffice 365 pers` will map to itself.

A small change has also been added to the `_matches_list` so that duplicates are dropped.