### PR TITLE
Option to add words to list of n-grams

### DIFF
--- a/string_grouper/string_grouper.py
+++ b/string_grouper/string_grouper.py
@@ -135,10 +135,11 @@ class StringGrouper(object):
         # After the StringGrouper is build, _matches_list will contain the indices and similarities of two matches
         self._matches_list: pd.DataFrame = pd.DataFrame()
 
-    def n_grams(self, string: str) -> List[str]:
+    def n_grams(self, string: str, add_words: bool=False) -> List[str]:
         """
         :param string: string to create ngrams from
-        :return: list of ngrams
+        :param add_words: boolean. Add words to list of ngrams
+        :return: list of ngrams (or ngrams and words)
         """
         ngram_size = self._config.ngram_size
         regex_pattern = self._config.regex
@@ -146,7 +147,10 @@ class StringGrouper(object):
             string = string.lower()  # lowercase to ignore all case
         string = re.sub(regex_pattern, r'', string)
         n_grams = zip(*[string[i:] for i in range(ngram_size)])
-        return [''.join(n_gram) for n_gram in n_grams]
+        if add_words==True:
+            return string.split(' ') + [''.join(ngram) for ngram in ngrams]
+        else:
+            return [''.join(n_gram) for n_gram in n_grams]
 
     def fit(self) -> 'StringGrouper':
         """Builds the _matches list which contains string matches indices and similarity"""


### PR DESCRIPTION
#### Description
 
The  `n_grams()` method returns a list of *n* contiguous characters from a string. This pull request gives the end user the option to include words to the original list of n-grams, if needed.

#### Example

In the following, we set `ngram_size` equal to 2.

```
# default behavior
>>> my_string = "FOO BAR"
>>> print(n_grams(string=my_string))
['FO', 'OO', 'O ', ' B', 'BA', 'AR']

# adding words to vector space
>>> print(n_grams(string=my_string, add_words=True))
['FOO', 'BAR', 'FO', 'OO', 'O ', ' B', 'BA', 'AR']
```

#### Motivation

In entity matching problems, the frequency of certain words may be high relative to others. This is especially true when trying to match company names (e.g., "Inc/Limited/LLC/Services/Company" are commonly used as suffixes or prefixes). Adding words to the vector space of n-grams will decrease the weight of these "stop words" in the resulting TF-IDF matrix, thus reducing their overall impact on the cosine similarity measure. For instance, "Facebook Inc" and "Google Inc" will have a lower similarity score (which is the sought-after result in this case). 

---

#### EDIT 

There's an unfortunate flaw I discovered with my submisssion. The default regex pattern removes white space characters which I did not take into consideration. Hence, taking the example above, the words will not be separated at all (the output will actually be the following: `['FOOBAR', 'FO', 'OO', 'OB', 'BA', 'AR']`). 

If you think this addition could be helpful, I'd be happy to take another look at it and find an appropriate solution. 