### PR TITLE
fixed Microsoft Windows 10 issue with numpy int datatype mismatch.

### DIFF
--- a/string_grouper/string_grouper.py
+++ b/string_grouper/string_grouper.py
@@ -487,8 +487,8 @@ class StringGrouper(object):
         sparserows = non_zeros[0]
         sparsecols = non_zeros[1]
         nr_matches = sparsecols.size
-        master_side = np.empty([nr_matches], dtype=int)
-        dupe_side = np.empty([nr_matches], dtype=int)
+        master_side = np.empty([nr_matches], dtype=np.int64)
+        dupe_side = np.empty([nr_matches], dtype=np.int64)
         similarity = np.zeros(nr_matches)
 
         for index in range(0, nr_matches):


### PR DESCRIPTION
Hi @Bergvca ,

Thanks to @StevenMaude's GitHub Workflow Action tests, I've been able to fix the int issue on Windows 10 (see my [comment](https://github.com/Bergvca/string_grouper/pull/44#issuecomment-817368169)).

At the same time, the tests also run successfully on Ubuntu.