### PR TITLE
updated string_grouper_utils.py to quell unittest deprecated warnings

### DIFF
--- a/string_grouper_utils/string_grouper_utils.py
+++ b/string_grouper_utils/string_grouper_utils.py
@@ -1,7 +1,7 @@
-import numpy as np
 import pandas as pd
 from typing import List, Optional, Union
 from dateutil.parser import parse
+from dateutil.tz import UTC
 from numbers import Number
 from datetime import datetime
 import re
@@ -143,13 +143,13 @@ def parse_timestamps(timestamps: pd.Series, parserinfo=None, **kwargs) -> pd.Ser
         # if any of the strings is not datetime-like raise an exception
         if timestamps.to_frame().applymap(is_date).squeeze().all():
             # convert strings to numpy datetime64
-            return timestamps.transform(lambda x: np.datetime64(parse(x, parserinfo, **kwargs)))
+            return timestamps.transform(lambda x: parse(x, parserinfo, **kwargs).astimezone(UTC))
     elif is_series_of_type(type(pd.Timestamp('15-1-2000')), timestamps):
         # convert pandas Timestamps to numpy datetime64
         return timestamps.transform(lambda x: x.to_numpy())
     elif is_series_of_type(datetime, timestamps):
         # convert python datetimes to numpy datetime64
-        return timestamps.transform(lambda x: np.datetime64(x))
+        return timestamps.transform(lambda x: x.astimezone(UTC))
     elif is_series_of_type(Number, timestamps):
         return timestamps
     raise Exception(error_msg)


### PR DESCRIPTION
Notify @Bergvca:

Tests on sub-package `string_grouper_utils` kept outputting deprecated warnings.  This PR fixes this issue.

###  BEFORE THE FIX:

```cmd
============================= test session starts =============================
platform win32 -- Python 3.9.2, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: C:\Users\heamu\eclipse-workspace\string_grouper
plugins: anyio-2.2.0
collected 16 items

string_grouper_utils\test\test_string_grouper_utils.py ................

============================== warnings summary ===============================
string_grouper_utils/test/test_string_grouper_utils.py::StringGrouperUtilTest::test_group_rep_by_timestamp_dateutil_timestamps
string_grouper_utils/test/test_string_grouper_utils.py::StringGrouperUtilTest::test_group_rep_by_timestamp_dateutil_timestamps
string_grouper_utils/test/test_string_grouper_utils.py::StringGrouperUtilTest::test_group_rep_by_timestamp_dateutil_timestamps
string_grouper_utils/test/test_string_grouper_utils.py::StringGrouperUtilTest::test_group_rep_by_timestamp_dateutil_timestamps
string_grouper_utils/test/test_string_grouper_utils.py::StringGrouperUtilTest::test_group_rep_by_timestamp_dateutil_timestamps
string_grouper_utils/test/test_string_grouper_utils.py::StringGrouperUtilTest::test_group_rep_by_timestamp_dateutil_timestamps
  C:\Users\heamu\eclipse-workspace\string_grouper\string_grouper_utils\string_grouper_utils.py:152: DeprecationWarning: parsing timezone aware datetimes is deprecated; this will raise an error in the future
    return timestamps.transform(lambda x: np.datetime64(x))

string_grouper_utils/test/test_string_grouper_utils.py: 18 warnings
  C:\Users\heamu\eclipse-workspace\string_grouper\string_grouper_utils\string_grouper_utils.py:146: DeprecationWarning: parsing timezone aware datetimes is deprecated; this will raise an error in the future
    return timestamps.transform(lambda x: np.datetime64(parse(x, parserinfo, **kwargs)))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================= 16 passed, 24 warnings in 0.83s =======================
```

### AFTER THE FIX:

```cmd
============================= test session starts =============================
platform win32 -- Python 3.9.2, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: C:\Users\heamu\eclipse-workspace\string_grouper
plugins: anyio-2.2.0
collected 16 items

string_grouper_utils\test\test_string_grouper_utils.py ................

============================= 16 passed in 0.85s ==============================
```