### PR TITLE
Change applymap to map to remove "FutureWarning: DataFrame.applymap h…as been deprecated. Use DataFrame.map instead."

### DIFF
--- a/string_grouper/string_grouper.py
+++ b/string_grouper/string_grouper.py
@@ -1147,7 +1147,7 @@ class StringGrouper(object):
     def _is_series_of_strings(series_to_test: pd.Series) -> bool:
         if not isinstance(series_to_test, pd.Series):
             return False
-        elif series_to_test.to_frame().applymap(
+        elif series_to_test.to_frame().map(
                     lambda x: not isinstance(x, str)
                 ).squeeze(axis=1).any():
             return False


### PR DESCRIPTION
There appears to a deprecation future warning on the applymap function within pandas when applied to data frames. This change moves the function to map as recommended by the warning.