### PR TITLE
Update string_grouper.py for pandas

### DIFF
--- a/string_grouper/string_grouper.py
+++ b/string_grouper/string_grouper.py
@@ -1147,7 +1147,7 @@ class StringGrouper(object):
     def _is_series_of_strings(series_to_test: pd.Series) -> bool:
         if not isinstance(series_to_test, pd.Series):
             return False
-        elif series_to_test.to_frame().applymap(
+        elif series_to_test.to_frame().map(
                     lambda x: not isinstance(x, str)
                 ).squeeze(axis=1).any():
             return False


### PR DESCRIPTION
Pandas has deprecated applymap. Changing to map is the indicated change, and works without any additional changes.

FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.