### PR TITLE
Bump some dependancies versions (pandas scipy numpy,...) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+.idea/
 
 __pycache__
 */__pycache__/
@@ -16,5 +16,6 @@ build/
 
 site/
 
-
 tests.txt
+
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "string_grouper"
-version = "0.7.1"
+version = "0.7.2"
 description = "String grouper contains functions to do string matching using TF-IDF and the cossine similarity."
 authors = [
     {name = "Chris van den Berg"},
@@ -14,7 +14,7 @@ maintainers = [
     {name = "Vincent Chalmel"},
 ]
 
-license = "MIT License"
+license = "MIT"
 readme = "README.md"
 
 packages = [
@@ -32,3 +32,7 @@ dependencies = [
     "sparse-dot-topn>=1.1.0",
     "loguru>0.7.0",
 ]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,14 @@ description = "String grouper contains functions to do string matching using TF-
 authors = [
     {name = "Chris van den Berg"},
     {name = "ParticularMiner"},
+    {name = "Vincent Chalmel"},
 ]
 
 maintainers = [
     {name = "Chris van den Berg"},
     {name = "Guillaume Pressiat"},
+    {name = "Vincent Chalmel"},
 ]
-
 
 license = "MIT License"
 readme = "README.md"
@@ -21,15 +22,13 @@ packages = [
     { include = "string_grouper_utils" },
 ]
 
-[tool.poetry.dependencies]
-python = "^3.9"
-pandas = "^2.0"
-scipy = ">=1.4.1"
-scikit-learn = "^1.4.0"
-numpy = "^1.26.0"
-sparse_dot_topn = ">=1.1.0"
-loguru = ">0.7.0"
+requires-python = "<4.0,>=3.9"
 
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+dependencies = [
+    "pandas<3.0,>=2.0",
+    "scipy>=1.4.1",
+    "scikit-learn<2.0.0,>=1.4.0",
+    "numpy<2.0.0,>=1.26.0",
+    "sparse-dot-topn>=1.1.0",
+    "loguru>0.7.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,13 @@ packages = [
     { include = "string_grouper_utils" },
 ]
 
-requires-python = "<4.0,>=3.9"
+requires-python = "<4.0,>=3.10"
 
 dependencies = [
     "pandas<3.0,>=2.0",
-    "scipy>=1.4.1",
-    "scikit-learn<2.0.0,>=1.4.0",
-    "numpy<2.0.0,>=1.26.0",
+    "scipy>=1.15",
+    "scikit-learn>=1.4.0",
+    "numpy>=2.0",
     "sparse-dot-topn>=1.1.0",
     "loguru>0.7.0",
 ]


### PR DESCRIPTION
Hi @Bergvca 

I had to use your string_grouper package on a project and couldn't downgrade some deps (e.g. numpy was had the most important version gap) so I used uv to get some working updated dependancies.

Tests are passing, and I built / used the new package without issues.

I understand that switching from poetry to uv might not be in your plans, and you might wand to do further testing to ensure compatibility ; Anyway, I thought it could be useful to submit this pull request to your review for consideration.
